### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "tuupola/base62": "^0.8.0 || ^0.9.0 || ^0.10.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^5.7 || ^6.5",
         "squizlabs/php_codesniffer": "^3.0",
         "overtrue/phplint": "^1.0",
         "nyholm/nsa": "^1.1",

--- a/tests/BrancaTest.php
+++ b/tests/BrancaTest.php
@@ -97,4 +97,13 @@ class BrancaTest extends TestCase
         $token = $branca->encode("Hello world!");
         $decoded = $branca->decode("XX{$token}XX");
     }
+
+    public function testShouldDecodeThrowInvalidToken()
+    {
+        $this->expectException(\RuntimeException::class);
+        $key = "supersecretkeyyoushouldnotcommit";
+        $branca = new Branca($key);
+        $token = $branca->encode("Hello world!");
+        $decoded = $branca->decode(str_replace('Y', 'X', $token));
+    }
 }

--- a/tests/BrancaTest.php
+++ b/tests/BrancaTest.php
@@ -104,6 +104,6 @@ class BrancaTest extends TestCase
         $key = "supersecretkeyyoushouldnotcommit";
         $branca = new Branca($key);
         $token = $branca->encode("Hello world!");
-        $decoded = $branca->decode(str_replace('Y', 'X', $token));
+        $decoded = $branca->decode(strrev($token));
     }
 }


### PR DESCRIPTION
# Changed log

- add more test.
- set the PHPUnit version ```6.5``` to solve the warning message when executing the ```php-7.2``` test in Travis build.