### PR TITLE
Remove nonce nonsense

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "phpunit/phpunit": "^5.0|^6.0|^7.0",
         "squizlabs/php_codesniffer": "^2.0|^3.0",
         "overtrue/phplint": "^1.0",
-        "nyholm/nsa": "^1.0",
         "phpstan/phpstan": "^0.9.1"
     },
     "autoload": {

--- a/src/Branca.php
+++ b/src/Branca.php
@@ -43,7 +43,6 @@ class Branca
     const VERSION = 0xBA; /* Magic byte, BrancA. */
 
     private $key;
-    private $nonce = null; /* This exists only for unit testing. */
 
     public function __construct(string $key)
     {
@@ -63,11 +62,7 @@ class Branca
 
         $version = pack("C", self::VERSION);
         $time = pack("N", $timestamp);
-
-        $nonce = $this->nonce;
-        if (empty($nonce)) {
-            $nonce = random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
-        }
+        $nonce = random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
 
         $header = $version . $time . $nonce;
 

--- a/src/Branca.php
+++ b/src/Branca.php
@@ -130,4 +130,11 @@ class Branca
 
         return $payload;
     }
+
+    public function timestamp(string $token): int
+    {
+        $token = (new Base62)->decode($token);
+        $parts = unpack("Cversion/Ntime", $token);
+        return $parts["time"];
+    }
 }

--- a/tests/BrancaTest.php
+++ b/tests/BrancaTest.php
@@ -126,12 +126,4 @@ class BrancaTest extends TestCase
         $branca = new Branca("supersecretkeyyoushouldnotcommit");
         $this->assertEquals(123206400, $branca->timestamp($token));
     }
-
-    public function testShouldGetTimestamp()
-    {
-        $key = "supersecretkeyyoushouldnotcommit";
-        $token = "1jJDJOEeG2FutA8g7NAOHK4Mh5RIE8jtbXd63uYbrFDSR06dtQl9o2gZYhBa36nZHXVfiGFz";
-        $branca = new Branca($key);
-        $this->assertEquals(123206400, $branca->timestamp($token));
-    }
 }

--- a/tests/BrancaTest.php
+++ b/tests/BrancaTest.php
@@ -176,4 +176,12 @@ class BrancaTest extends TestCase
         $key = "tooshortkey";
         $branca = new Branca($key);
     }
+
+    public function testShouldGetTimestamp()
+    {
+        $key = "supersecretkeyyoushouldnotcommit";
+        $token = "1jJDJOEeG2FutA8g7NAOHK4Mh5RIE8jtbXd63uYbrFDSR06dtQl9o2gZYhBa36nZHXVfiGFz";
+        $branca = new Branca($key);
+        $this->assertEquals(123206400, $branca->timestamp($token));
+    }
 }


### PR DESCRIPTION
Nonce is now always generated, even in unit tests. This is to avoid anyone misunderstanding that user should be able to provide his or hers own nonce.